### PR TITLE
Fix Windows compatibility for Docker entrypoint

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,35 @@
+# Ensure shell scripts always use LF line endings
+*.sh text eol=lf
+entrypoint.sh text eol=lf
+
+# Python files should use LF
+*.py text eol=lf
+
+# Docker files should use LF
+Dockerfile text eol=lf
+docker-compose.yml text eol=lf
+docker-compose.yaml text eol=lf
+
+# Config files should use LF
+*.conf text eol=lf
+*.cfg text eol=lf
+*.ini text eol=lf
+*.json text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
+
+# Documentation files
+*.md text eol=lf
+*.txt text eol=lf
+
+# Windows batch files should use CRLF
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# Binary files
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary

--- a/Backend/api/Dockerfile
+++ b/Backend/api/Dockerfile
@@ -48,6 +48,13 @@ RUN ln -s /app/event_generators /event_generators \
 # Create data directory for ephemeral database
 RUN mkdir -p /app/data
 
+# Fix Windows line endings for shell script
+RUN apt-get update && apt-get install -y dos2unix && \
+    dos2unix /app/entrypoint.sh && \
+    apt-get remove -y dos2unix && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
+
 # Create non-root user
 RUN useradd -m -u 1000 jarvis && \
     chown -R jarvis:jarvis /app && \


### PR DESCRIPTION
## Summary
- Fixes the entrypoint.sh execution failure on Windows machines
- Addresses line ending compatibility issues (CRLF vs LF)
- Implements both immediate and long-term solutions

## Changes
1. **Dockerfile Update**: Added dos2unix conversion to fix line endings during Docker build
2. **Git Attributes**: Created .gitattributes file to enforce LF line endings for shell scripts and other text files

## Test Plan
- [ ] Build Docker image on Windows machine
- [ ] Verify entrypoint.sh executes without "no such file or directory" errors
- [ ] Confirm API container starts successfully
- [ ] Test that existing Linux/Mac deployments still work

## Issue
Resolves the API layer failure on Windows machines where entrypoint.sh couldn't be executed due to incorrect line endings.

🤖 Generated with [Claude Code](https://claude.ai/code)