### PR TITLE
Fix API documentation URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ docker compose up -d --build
 ```
 - **API**: http://localhost:8000
 - **Frontend UI**: http://localhost:9001
-- **API Docs**: http://localhost:8000/docs
+- **API Docs**: http://localhost:8000/api/v1/docs
 
 ### 3. Stop Services
 ```bash


### PR DESCRIPTION
## Summary
- Corrects the API documentation URL from `/docs` to `/api/v1/docs`
- Updates README to reflect the actual endpoint where Swagger UI is served

## Background
The FastAPI application serves its automatic API documentation at `/api/v1/docs` due to the API router mounting configuration, not at the root `/docs` path. This was causing confusion for users trying to access the API documentation.

## Changes
- Updated README.md to show the correct URL: `http://localhost:8000/api/v1/docs`

## Test plan
- [x] Verified API docs are accessible at `/api/v1/docs`
- [x] Confirmed `/docs` returns 404
- [x] Tested with `curl http://localhost:8000/api/v1/docs` - returns Swagger UI HTML

🤖 Generated with [Claude Code](https://claude.ai/code)