### PR TITLE
fix: write scenario files to writable /app/data directory

### DIFF
--- a/Backend/scenarios/enterprise_attack_scenario.py
+++ b/Backend/scenarios/enterprise_attack_scenario.py
@@ -634,10 +634,18 @@ def generate_enhanced_attack_scenario():
 
 def save_scenario(scenario, filename="enterprise_attack_scenario.json"):
     """Save scenario to file"""
-    with open(filename, 'w') as f:
+    # Use /app/data directory which is writable in the container
+    data_dir = "/app/data"
+    
+    # Create the directory if it doesn't exist
+    os.makedirs(data_dir, exist_ok=True)
+    
+    filepath = os.path.join(data_dir, filename)
+    
+    with open(filepath, 'w') as f:
         json.dump(scenario, f, indent=2, default=str)
-    print(f"\n📁 Scenario saved to: {filename}")
-    return filename
+    print(f"\n📁 Scenario saved to: {filepath}")
+    return filepath
 
 if __name__ == "__main__":
     scenario = generate_enhanced_attack_scenario()

--- a/Backend/scenarios/enterprise_attack_scenario_10min.py
+++ b/Backend/scenarios/enterprise_attack_scenario_10min.py
@@ -546,10 +546,21 @@ def generate_10min_attack_scenario():
 
 def save_scenario(scenario, filename="enterprise_attack_scenario_10min.json"):
     """Save scenario to file"""
-    with open(filename, 'w') as f:
+    # Use /app/data directory which is writable in the container
+    data_dir = "/app/data"
+    if not os.path.exists(data_dir):
+        # Fallback to current directory if /app/data doesn't exist (local dev)
+        data_dir = "."
+    
+    filepath = os.path.join(data_dir, filename)
+    
+    # Ensure the directory exists
+    os.makedirs(os.path.dirname(filepath) if os.path.dirname(filepath) else data_dir, exist_ok=True)
+    
+    with open(filepath, 'w') as f:
         json.dump(scenario, f, indent=2, default=str)
-    print(f"\n📁 Scenario saved to: {filename}")
-    return filename
+    print(f"\n📁 Scenario saved to: {filepath}")
+    return filepath
 
 if __name__ == "__main__":
     scenario = generate_10min_attack_scenario()

--- a/Backend/scenarios/showcase_attack_scenario.py
+++ b/Backend/scenarios/showcase_attack_scenario.py
@@ -278,10 +278,21 @@ def generate_showcase_attack_scenario():
 
 def save_scenario(scenario, filename="showcase_attack_scenario.json"):
     """Save scenario to file"""
-    with open(filename, 'w') as f:
+    # Use /app/data directory which is writable in the container
+    data_dir = "/app/data"
+    if not os.path.exists(data_dir):
+        # Fallback to current directory if /app/data doesn't exist (local dev)
+        data_dir = "."
+    
+    filepath = os.path.join(data_dir, filename)
+    
+    # Ensure the directory exists
+    os.makedirs(os.path.dirname(filepath) if os.path.dirname(filepath) else data_dir, exist_ok=True)
+    
+    with open(filepath, 'w') as f:
         json.dump(scenario, f, indent=2, default=str)
-    print(f"\n📁 Scenario saved to: {filename}")
-    return filename
+    print(f"\n📁 Scenario saved to: {filepath}")
+    return filepath
 
 if __name__ == "__main__":
     print("🏢 ENTERPRISE SHOWCASE ATTACK SCENARIO GENERATOR")


### PR DESCRIPTION
## Problem
Running scenarios from the UI in Docker containers failed with:
`OSError: [Errno 30] Read-only file system`

## Solution  
Modified [save_scenario()](cci:1://file:///Users/Marco.Rottigni/Library/CloudStorage/GoogleDrive-marco.rottigni@sentinelone.com/My%20Drive/Solutions%20Architect%20SecOps/jarvis_coding/Backend/scenarios/showcase_attack_scenario.py:278:0-294:19) in 3 scenario files to write to `/app/data` 
(writable) instead of current directory (read-only scenarios mount).

## Files Changed
- Backend/scenarios/enterprise_attack_scenario.py
- Backend/scenarios/enterprise_attack_scenario_10min.py
- Backend/scenarios/showcase_attack_scenario.py

## Testing
Tested in Docker - Enterprise Breach Scenario now executes successfully.